### PR TITLE
Fix in pessimistic assignment rule

### DIFF
--- a/lib/src/main/java/fi/smaa/jsmaa/model/electre/ElectreTri.java
+++ b/lib/src/main/java/fi/smaa/jsmaa/model/electre/ElectreTri.java
@@ -96,6 +96,7 @@ public class ElectreTri {
 						break;
 					}
 					if (i == categories.size()-2) {
+						cat = categories.get((i+1));
 						resMap.put(a, cat);
 					}
 				}

--- a/lib/src/test/java/fi/smaa/jsmaa/simulator/SMAATRISimulationTest.java
+++ b/lib/src/test/java/fi/smaa/jsmaa/simulator/SMAATRISimulationTest.java
@@ -132,8 +132,8 @@ public class SMAATRISimulationTest {
 		SMAATRIResults res = runModel(model);
 		Map<Alternative, List<Double>> accs = res.getCategoryAcceptabilities();
 		
-		assertEquals(1.0, accs.get(alt1).get(0), 0.00001);
-		assertEquals(0.0, accs.get(alt1).get(1), 0.00001);
+		assertEquals(0.0, accs.get(alt1).get(0), 0.00001);
+		assertEquals(1.0, accs.get(alt1).get(1), 0.00001);
 		
 		assertEquals(1.0, accs.get(alt2).get(0), 0.00001);
 		assertEquals(0.0, accs.get(alt2).get(1), 0.00001);	


### PR DESCRIPTION
Fixed bug: When the pessimistic assignment rule is used in a SMAA-TRI model, alternatives can not be assigned to the highest class (C_h).
